### PR TITLE
Reduces Price of the ZX Shotgun

### DIFF
--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -216,7 +216,7 @@ WEAPONS
 /datum/supply_packs/weapons/zx76
 	name = "ZX-76 Twin-Barrled Burst Shotgun"
 	contains = list(/obj/item/weapon/gun/shotgun/zx76)
-	cost = 90
+	cost = 100
 
 /datum/supply_packs/weapons/autosniper
 	name = "IFF Auto Sniper kit"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -216,7 +216,7 @@ WEAPONS
 /datum/supply_packs/weapons/zx76
 	name = "ZX-76 Twin-Barrled Burst Shotgun"
 	contains = list(/obj/item/weapon/gun/shotgun/zx76)
-	cost = 120
+	cost = 80
 
 /datum/supply_packs/weapons/autosniper
 	name = "IFF Auto Sniper kit"

--- a/code/modules/reqs/supplypacks.dm
+++ b/code/modules/reqs/supplypacks.dm
@@ -216,7 +216,7 @@ WEAPONS
 /datum/supply_packs/weapons/zx76
 	name = "ZX-76 Twin-Barrled Burst Shotgun"
 	contains = list(/obj/item/weapon/gun/shotgun/zx76)
-	cost = 80
+	cost = 90
 
 /datum/supply_packs/weapons/autosniper
 	name = "IFF Auto Sniper kit"


### PR DESCRIPTION
## About The Pull Request

Reduces price of the ZX Burst shotgun from 120 points to 80 points.

## Why It's Good For The Game

The ZX is probably a very fun weapon. Due to its cost, it's also used enormously infrequently; in any circumstances where one can buy a ZX, a set of B18 is almost always worth the price instead. Dropping the cost of the ZX to minigun levels will allow the weapon to actually be used, as well as give a frame of reference for its actual effectiveness.

## Changelog
:cl:
balance: Reduced price of the ZX Burst shotgun from 120 to 80.
/:cl: